### PR TITLE
[ew-3547] thinkenergy sso

### DIFF
--- a/lib/omniauth/strategies/saml/auth_request.rb
+++ b/lib/omniauth/strategies/saml/auth_request.rb
@@ -35,7 +35,14 @@ module OmniAuth
           end
 
           encoded_request   = CGI.escape(base64_request)
-          request_params    = "?SAMLRequest=" + encoded_request
+          delimiter =
+            if settings[:idp_sso_target_url].include?('?')
+              '&'
+            else
+              '?'
+            end
+
+          request_params    = "#{delimiter}SAMLRequest=" + encoded_request
 
           params.each_pair do |key, value|
             request_params << "&#{key}=#{CGI.escape(value.to_s)}"


### PR DESCRIPTION
#### Jira Ticket(s)

[ew-3547](https://jira.tendrilinc.com/browse/ew-3547)
#### What was the problem/requirement?

Thinkenergy uses an idp url with query params and our gem wasn't equipped to handle that.
#### What was the solution?

Use the correct delimeter if there are already query params present.
#### What is the impact of this change?

SSO for Thinkenergy works now.
#### How to test this change?

Login using sso on think energy.
