### PR TITLE
[ew-3547] handle target idp with query params

### DIFF
--- a/lib/omniauth/strategies/saml/auth_request.rb
+++ b/lib/omniauth/strategies/saml/auth_request.rb
@@ -35,7 +35,9 @@ module OmniAuth
           end
 
           encoded_request   = CGI.escape(base64_request)
-          request_params    = "?SAMLRequest=" + encoded_request
+
+          delimiter = settings[:idp_sso_target_url].include?('?') ? '&' : '?'
+          request_params = "#{delimiter}SAMLRequest=#{encoded_request}"
 
           params.each_pair do |key, value|
             request_params << "&#{key}=#{CGI.escape(value.to_s)}"


### PR DESCRIPTION
#### Jira Ticket(s)

[ew-3547](https://jira.tendrilinc.com/browse/ew-3547)
#### What was the problem/requirement?

Thinkenergy uses an idp with query params in the url. Our gem doesn't handle
cases where query params are present. It simply prepends appends a
'?SAMLRequest' onto the idp url. If there are already query params present we
need to add a '&SAMLRequest' instead. Without this change the parser doesn't
pick up the SAMLRequest key as a param.
#### What was the solution?

Detect if there are query params in the url, if so use the correct delimiter.
#### What is the impact of this change?

SSO now works in thinkenergy.
#### How to test this change?

Deploy to sandbox and login using SSO, then log out of the energize app and try
to navigate back. You should be logged in.

See Aaron or Tom for credentials of a user you can test with.
