### PR TITLE
ew-3361 need to be able to configure both signature and digest algorthms

### DIFF
--- a/lib/omniauth/strategies/saml/xml_security.rb
+++ b/lib/omniauth/strategies/saml/xml_security.rb
@@ -87,8 +87,11 @@ module OmniAuth
             canon_string            = signed_info_element.canonicalize( canon_method )
             base64_signature        = self.at_xpath(".//ds:SignatureValue", { "ds" => DSIG }).text
             signature               = Base64.decode64(base64_signature)
-            if !cert.public_key.verify(digest_for_algorithm(settings.idp_digest_algorithm).new, signature, canon_string)
+            if !cert.public_key.verify(digest_for_algorithm(settings.idp_signature_algorithm).new, signature, canon_string)
+              SAML::log :error, "=========================="
               SAML::log :error, "Key Validation Error."
+              SAML::log :error, OpenSSL.errors.inspect
+              SAML::log :error, "=========================="
               SAML::log :error, "  settings: " + settings.inspect
               return soft ? false : (raise OmniAuth::Strategies::SAML::ValidationError.new("Key validation error"))
             end


### PR DESCRIPTION
ew-3361 need to be able to configure both signature and digest algorthms


Alliant configuration has the signature set to SHA1  and the digest algorithm set to SHA256.  Current config options do not allow this.   

Solution is to split these into two separate config options:

settings.idp_digest_algorithm
settings.idp_signature_algorithm

These are set and passed in from energize via the following TENANT_CONFIGs:

SSO_SAML_IDP_DIGEST_ALGORITHM
SSO_SAML_IDP_SIGNATURE_ALGORITHM
